### PR TITLE
feat: Ceph & other S3-compatible database-based storages are working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,11 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
 
     // libs
-    api 'io.minio:minio:8.5.10'
+    api ('io.minio:minio:8.5.10') {
+        exclude (group: 'com.fasterxml.jackson.core', module: 'jackson-core')
+        exclude (group: 'com.fasterxml.jackson.core', module: 'jackson-databind')
+        exclude (group: 'com.fasterxml.jackson.core', module: 'jackson-annotations')
+    }
 }
 
 

--- a/src/test/java/io/kestra/storage/minio/MinioStorageTest.java
+++ b/src/test/java/io/kestra/storage/minio/MinioStorageTest.java
@@ -22,20 +22,20 @@ class MinioStorageTest extends StorageTestSuite {
     @BeforeEach
     void init() throws Exception {
         String bucket = ((MinioStorage) storage).getBucket();
-        if (!((MinioStorage) storage).miniClient().bucketExists(BucketExistsArgs.builder().bucket(bucket).build())) {
-            ((MinioStorage) storage).miniClient().makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+        if (!((MinioStorage) storage).minioClient().bucketExists(BucketExistsArgs.builder().bucket(bucket).build())) {
+            ((MinioStorage) storage).minioClient().makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
         }
     }
 
     @Test
     void checkVhostOff() throws Exception {
         ByteArrayOutputStream traceStream = new ByteArrayOutputStream();
-        ((MinioStorage) storage).miniClient().traceOn(traceStream);
+        ((MinioStorage) storage).minioClient().traceOn(traceStream);
         try {
             storage.list(null, URI.create("/"));
             assertThat(traceStream.toString(), containsString("Host: " + ((MinioStorage) storage).getEndpoint()));
         } finally {
-            ((MinioStorage) storage).miniClient().traceOff();
+            ((MinioStorage) storage).minioClient().traceOff();
         }
     }
 }

--- a/src/test/java/io/kestra/storage/minio/MinioStorageVhostTest.java
+++ b/src/test/java/io/kestra/storage/minio/MinioStorageVhostTest.java
@@ -24,7 +24,7 @@ class MinioStorageVhostTest {
     StorageInterface storage;
     @BeforeEach
     void init() throws Exception {
-        MinioClient minioClient = ((MinioStorage) storage).miniClient();
+        MinioClient minioClient = ((MinioStorage) storage).minioClient();
         if (!minioClient.bucketExists(BucketExistsArgs.builder().bucket(((MinioStorage) storage).getBucket()).build())) {
             minioClient.makeBucket(MakeBucketArgs.builder().bucket(((MinioStorage) storage).getBucket()).build());
         }
@@ -33,7 +33,7 @@ class MinioStorageVhostTest {
     @Test
     void checkVhostOn() throws Exception {
         ByteArrayOutputStream traceStream = new ByteArrayOutputStream();
-        MinioClient minioClient = ((MinioStorage) storage).miniClient();
+        MinioClient minioClient = ((MinioStorage) storage).minioClient();
         minioClient.traceOn(traceStream);
         try {
             storage.list(null, URI.create("/"));


### PR DESCRIPTION
fixes https://github.com/kestra-io/kestra/issues/4160

However, it also introduces a breaking change for Ceph & other S3-compatible database-based storages as we no longer have a leading slash in paths. Minio users are not impacted

Prior to this PR, Namespace files listing was not working as well as CP / MV files.

After this PR, to keep old data working (executions outputs / NS Files), you need to bulk move everything:
`s3cmd mv s3://{bucket}// s3://{bucket}/ --recursive`

Note that this is done prior to https://github.com/kestra-io/kestra/issues/3933 so a manual migration is needed