### PR TITLE
fix: dont do a full tenantId replace in paths to avoid removing it in…

### DIFF
--- a/src/main/java/io/kestra/storage/minio/MinioStorage.java
+++ b/src/main/java/io/kestra/storage/minio/MinioStorage.java
@@ -498,7 +498,7 @@ public class MinioStorage implements StorageInterface, MinioConfig {
         return deleted
             .stream()
             .map(Pair::getLeft)
-            .map(name -> name.replace(tenantId + "/", ""))
+            .map(name -> name.replaceFirst(tenantId + "/", ""))
             .map(name -> name.endsWith("/") ? name.substring(0, name.length() - 1) : name)
             .map(name -> URI.create("kestra:///" + name))
             .collect(Collectors.toList());


### PR DESCRIPTION
… namespaces

closes kestra-io/kestra#11293
