### PR TITLE
fix: copy&paste from storage-gcs

### DIFF
--- a/src/main/java/io/kestra/storage/minio/MinioStorage.java
+++ b/src/main/java/io/kestra/storage/minio/MinioStorage.java
@@ -531,7 +531,7 @@ public class MinioStorage implements StorageInterface, MinioConfig {
             try {
                 this.minioClient.close();
             } catch (Exception e) {
-                LOG.warn("Failed to close GcsStorage", e);
+                LOG.warn("Failed to close MinIO client", e);
             }
         }
     }


### PR DESCRIPTION
### What changes are being made and why?

Removed copy&paste leftover from [kestra-io/storage-gcs](https://github.com/kestra-io/storage-gcs/).