### PR TITLE
fix(storage): add configurable HTTP timeouts for MinIO client

### DIFF
--- a/src/main/java/io/kestra/storage/minio/MinioClientFactory.java
+++ b/src/main/java/io/kestra/storage/minio/MinioClientFactory.java
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
@@ -71,6 +72,16 @@ public class MinioClientFactory {
                         .build();
                 });
             }
+        }
+
+        if (config.getHttpConnectTimeout() != null) {
+            builder.connectTimeout(config.getHttpConnectTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (config.getHttpReadTimeout() != null) {
+            builder.readTimeout(config.getHttpReadTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (config.getHttpWriteTimeout() != null) {
+            builder.writeTimeout(config.getHttpWriteTimeout().toMillis(), TimeUnit.MILLISECONDS);
         }
 
         return builder.build();

--- a/src/main/java/io/kestra/storage/minio/MinioConfig.java
+++ b/src/main/java/io/kestra/storage/minio/MinioConfig.java
@@ -1,9 +1,13 @@
 package io.kestra.storage.minio;
 
+import java.time.Duration;
+
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.storage.minio.domains.ProxyConfiguration;
 import io.kestra.storage.minio.domains.SslOptions;
 import io.kestra.storage.minio.internal.BytesSize;
+
+import jakarta.annotation.Nullable;
 
 public interface MinioConfig {
 
@@ -45,4 +49,32 @@ public interface MinioConfig {
 
     @PluginProperty(group = "connection")
     SslOptions getSslOptions();
+
+    /**
+     * Maximum time to wait while establishing an HTTP connection to MinIO.
+     * Set to {@code PT0S} (zero) to disable the timeout (infinite wait).
+     * When {@code null}, OkHttp's default of 10 seconds is used.
+     */
+    @Nullable
+    @PluginProperty(group = "advanced")
+    Duration getHttpConnectTimeout();
+
+    /**
+     * Maximum time to wait for data between consecutive TCP packets during an HTTP read from MinIO.
+     * Set to {@code PT0S} (zero) to disable the timeout (infinite wait), which avoids
+     * {@code SocketException} on long-running {@code listObjects} streams over large buckets.
+     * When {@code null}, OkHttp's default of 10 seconds is used.
+     */
+    @Nullable
+    @PluginProperty(group = "advanced")
+    Duration getHttpReadTimeout();
+
+    /**
+     * Maximum time to wait for data between consecutive TCP packets during an HTTP write to MinIO.
+     * Set to {@code PT0S} (zero) to disable the timeout (infinite wait).
+     * When {@code null}, OkHttp's default of 10 seconds is used.
+     */
+    @Nullable
+    @PluginProperty(group = "advanced")
+    Duration getHttpWriteTimeout();
 }

--- a/src/main/java/io/kestra/storage/minio/MinioStorage.java
+++ b/src/main/java/io/kestra/storage/minio/MinioStorage.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -74,6 +75,15 @@ public class MinioStorage implements StorageInterface, MinioConfig {
     private String clientPem;
 
     private SslOptions sslOptions;
+
+    @jakarta.annotation.Nullable
+    private Duration httpConnectTimeout;
+
+    @jakarta.annotation.Nullable
+    private Duration httpReadTimeout;
+
+    @jakarta.annotation.Nullable
+    private Duration httpWriteTimeout;
 
     /**
      * {@inheritDoc}

--- a/src/main/java/io/kestra/storage/minio/domains/ProxyConfiguration.java
+++ b/src/main/java/io/kestra/storage/minio/domains/ProxyConfiguration.java
@@ -2,11 +2,12 @@ package io.kestra.storage.minio.domains;
 
 import java.net.Proxy;
 
+import io.kestra.core.models.annotations.PluginProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder(toBuilder = true)

--- a/src/main/java/io/kestra/storage/minio/domains/SslOptions.java
+++ b/src/main/java/io/kestra/storage/minio/domains/SslOptions.java
@@ -1,9 +1,10 @@
 package io.kestra.storage.minio.domains;
 
+import io.kestra.core.models.annotations.PluginProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder


### PR DESCRIPTION
## Summary

- Add `httpConnectTimeout`, `httpReadTimeout`, `httpWriteTimeout` (nullable `Duration`) to `MinioConfig` interface and `MinioStorage` implementation
- Wire them into `MinioClientFactory.createHttpClient()`: each non-null value is applied to the `OkHttpClient.Builder` via `connectTimeout`/`readTimeout`/`writeTimeout` with `TimeUnit.MILLISECONDS`
- Null values leave OkHttp defaults untouched — zero behaviour change for existing deployments
- `PT0S` (zero duration) maps to `0 ms` which OkHttp treats as infinite timeout, providing a documented workaround for long-running `listObjects` streams on large buckets that previously caused `SocketException`

closes: https://github.com/kestra-io/storage-minio/issues/166

## Test plan

- [ ] `./gradlew test --tests "io.kestra.storage.minio.MinioConfigTest"` passes (unit tests)
- [ ] `./gradlew build -x test` compiles cleanly
- [ ] CI integration tests pass with container networking