### PR TITLE
fix(minio): expose connection-pool keep-alive to prevent SocketException on stale connections

### DIFF
--- a/src/main/java/io/kestra/storage/minio/MinioClientFactory.java
+++ b/src/main/java/io/kestra/storage/minio/MinioClientFactory.java
@@ -23,6 +23,7 @@ import io.minio.credentials.IamAwsProvider;
 import io.minio.credentials.MinioEnvironmentProvider;
 import io.minio.credentials.Provider;
 import io.minio.credentials.StaticProvider;
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 
 public class MinioClientFactory {
@@ -83,6 +84,12 @@ public class MinioClientFactory {
         if (config.getHttpWriteTimeout() != null) {
             builder.writeTimeout(config.getHttpWriteTimeout().toMillis(), TimeUnit.MILLISECONDS);
         }
+
+        // Default 30s is intentionally shorter than OkHttp's 5-min default to stay below
+        // typical k8s/Istio idle-connection kill timers (~10–60s), preventing stale-connection SocketException.
+        var keepAlive = config.getHttpConnectionKeepAlive();
+        long keepAliveMs = keepAlive != null ? keepAlive.toMillis() : 30_000L;
+        builder.connectionPool(new ConnectionPool(5, keepAliveMs, TimeUnit.MILLISECONDS));
 
         return builder.build();
     }

--- a/src/main/java/io/kestra/storage/minio/MinioConfig.java
+++ b/src/main/java/io/kestra/storage/minio/MinioConfig.java
@@ -77,4 +77,15 @@ public interface MinioConfig {
     @Nullable
     @PluginProperty(group = "advanced")
     Duration getHttpWriteTimeout();
+
+    /**
+     * Keep-alive duration for idle HTTP connections in the OkHttp connection pool.
+     * Connections idle longer than this are evicted before reuse, preventing
+     * {@code SocketException: Socket closed} when network infrastructure (Kubernetes,
+     * Istio, load balancers) closes TCP connections after a shorter idle period.
+     * Defaults to {@code PT30S} (30 seconds) when {@code null}.
+     */
+    @Nullable
+    @PluginProperty(group = "advanced")
+    Duration getHttpConnectionKeepAlive();
 }

--- a/src/main/java/io/kestra/storage/minio/MinioStorage.java
+++ b/src/main/java/io/kestra/storage/minio/MinioStorage.java
@@ -85,6 +85,9 @@ public class MinioStorage implements StorageInterface, MinioConfig {
     @jakarta.annotation.Nullable
     private Duration httpWriteTimeout;
 
+    @jakarta.annotation.Nullable
+    private Duration httpConnectionKeepAlive;
+
     /**
      * {@inheritDoc}
      **/


### PR DESCRIPTION
## Summary

- OkHttp's default connection-pool keep-alive is 5 minutes, far exceeding the ~10 s idle-connection kill timer enforced by Kubernetes / Istio in many customer environments. OkHttp tries to reuse the stale pooled socket on the next `listObjects` call and throws `SocketException: Socket closed`.
- Add `httpConnectionKeepAlive` (`Duration`) to `MinioConfig` and `MinioStorage`; wire it into `MinioClientFactory` as an explicit `ConnectionPool` override. The default is **30 seconds** instead of OkHttp's 300 s, keeping most deployments safe out of the box without any config change.
- Users running aggressive infra (e.g. Istio with a 10 s idle timeout) can set `http-connection-keep-alive: PT5S` in their plugin defaults.

Example configuration:

```yaml
pluginDefaults:
  - type: io.kestra.storage.minio.MinioStorage
    values:
      http-connection-keep-alive: PT5S   # stay below Istio's 10s idle kill timer
```

## Test plan

- [x] `rtk test ./gradlew test` passes (all storage tests green)
- [x] `rtk err ./gradlew build` compiles cleanly
- [ ] Deploy to a k8s/Istio cluster that kills idle TCP after ~10 s and verify `listObjects` no longer throws `SocketException: Socket closed`