### PR TITLE
chore(deps): bump gradle plugins, shadow, and gradle-wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'io.kestra.gradle.repository-conventions' version '1.2.3'
-    id 'io.kestra.gradle.spotless-conventions' version '1.2.1'
+    id 'io.kestra.gradle.repository-conventions' version '1.2.5'
+    id 'io.kestra.gradle.spotless-conventions' version '1.2.5'
     id "com.vanniktech.maven.publish" version "0.37.0"
-    id "io.kestra.gradle.inject-bom-versions" version "1.2.1"
-    id "io.kestra.gradle.plugin-doc-lint" version "1.2.4"
+    id "io.kestra.gradle.inject-bom-versions" version "1.2.5"
+    id "io.kestra.gradle.plugin-doc-lint" version "1.2.5"
     id "java-library"
     id "idea"
     id 'jacoco'
     id "com.adarshr.test-logger" version "4.0.0"
-    id "com.gradleup.shadow" version "9.4.2"
+    id "com.gradleup.shadow" version "9.4.3"
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Combines the open dependabot bumps into one PR:

- io.kestra.gradle.repository-conventions 1.2.3 -> 1.2.5 (#180)
- io.kestra.gradle.spotless-conventions 1.2.1 -> 1.2.5 (#176)
- io.kestra.gradle.inject-bom-versions 1.2.1 -> 1.2.5 (#177)
- io.kestra.gradle.plugin-doc-lint 1.2.4 -> 1.2.5 (#175)
- com.gradleup.shadow 9.4.2 -> 9.4.3 (#179)
- gradle-wrapper 9.6.0 -> 9.6.1 (#178)

lintPluginDocs passes locally (all 25 rules).
